### PR TITLE
fixes #32

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Fixed
 Changed
 *******
 - ``raster.Image()``: changed ``dn2toa(platform, metadata, wavelengths)`` to ``dn2toa(platform, mtl_file, wavelengths)`` #17
+- ``raster.Image()``: explicit dtype when writing, optional compression #32
 
 
 [0.3.0]  (2020-05-26)

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -3,7 +3,6 @@ import unittest
 
 import dask.array
 import numpy as np
-import rasterio
 from rasterio import windows
 from rasterio.coords import BoundingBox
 from rasterio.transform import from_bounds
@@ -184,14 +183,14 @@ class DataTest(unittest.TestCase):
         self.assertIsInstance(img.to_dask_array(chunk_size=(1, 10, 10)), dask.array.core.Array)
 
     def test_write_to_file(self):
-        img.write_to_file(r"result.tif", rasterio.uint16)
+        img.write_to_file(r"result.tif", np.uint16)
         img2 = Image("result.tif")
         self.assertTrue(np.array_equal(img2.arr, img.arr))
 
         img2.close()
         os.remove(r"result.tif")
 
-        img.write_to_file(r"result.tif", 'min', compress='lzw')
+        img.write_to_file(r"result.tif", "min", compress="lzw")
         img2 = Image("result.tif")
         self.assertEqual(img2.arr.dtype, "uint8")
         self.assertEqual(os.stat("result.tif").st_size, 10271)

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -197,7 +197,7 @@ class DataTest(unittest.TestCase):
         img.write_to_file(r"result.tif", "min", compress="lzw")
         img2 = Image("result.tif")
         self.assertEqual(img2.arr.dtype, "uint8")
-        self.assertEqual(os.stat("result.tif").st_size, 10271)
+        self.assertEqual(img2.dataset.profile["compress"], "lzw")
 
         img2.close()
         os.remove(r"result.tif")


### PR DESCRIPTION
closes #32 

The dtype is explicit, can optional use the minimum requirement dtype.