### PR TITLE
adding nodata as option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ something was changed
 [master]  (2020-06-16)
 ----------------------
 
+Added
+*****
+- `raster.Image()``: optional nodata value for writing #32
+
 Fixed
 *****
 - ``file.get_ts_from_sentinel_filename()``: Return datetime.datetime objects instead of timestamp strings #42

--- a/ukis_pysat/raster.py
+++ b/ukis_pysat/raster.py
@@ -363,13 +363,14 @@ class Image:
         self.da_arr = da.from_array(self.__arr, chunks=chunk_size)
         return self.da_arr
 
-    def write_to_file(self, path_to_file, dtype, driver="GTiff", compress=None):
+    def write_to_file(self, path_to_file, dtype, driver="GTiff", nodata=None, compress=None):
         """
         Write a dataset to file.
         :param path_to_file: str, path to new file
         :param dtype: datatype, like np.uint16, 'float32' or 'min' to use the minimum type to represent values
 
         :param driver: str, optional (default: 'GTiff')
+        :param nodata: nodata value, e.g. 255 (default: None, means nodata value of dataset will be used)
         :param compress: compression, e.g. 'lzw' (default: None)
         """
         if dtype == 'min':
@@ -386,6 +387,9 @@ class Image:
                 "crs": self.crs,
             }
         )
+
+        if nodata:
+            profile.update({"nodata": nodata})
 
         if compress:
             profile.update({"compress": compress})


### PR DESCRIPTION
Closes #32 again. 
_nodata_ is a useful addition, nbit or tiling are less popular IMO. You can always use rasterio directly for writing, e.g.:

```python

    profile = img.dataset.meta
    profile.update(
        {
            "driver": "GTiff",
            "height": img.arr.shape[-2],
            "width": img.arr.shape[-1],
            "dtype": "uint8",
            "transform": img.transform,
            "crs": img.crs,
            "nbits"="1",
            "tiled"="yes"
        }
    )

    with rasterio.open(dest, "w", **profile) as dst:
        dst.write(img.arr.astype("uint16"))
```



Please squash the commits.