### PR TITLE
passing meta to open new dataset

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Added
 Fixed
 *****
 - ``file.get_ts_from_sentinel_filename()``: Return datetime.datetime objects instead of timestamp strings #42
+- ``raster.Image()``: in-memory dataset could not be updated if not GTiff #48
 
 Changed
 *******


### PR DESCRIPTION
Closes #48 

This is all very confusing and to really understand the root of this we need to dig deep trough rasterio. The meta gets _only_ lost when the driver is not `GTiff`.

We should also have less problems with dangling datasets (#45).