### PR TITLE
simplification usage of crs and transform, no direct access

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,11 +23,12 @@ Added
 Fixed
 *****
 - ``file.get_ts_from_sentinel_filename()``: Return datetime.datetime objects instead of timestamp strings #42
-- ``raster.Image()``: in-memory dataset could not be updated if not GTiff #48
+- ``raster.Image()``: in-memory dataset could not be updated if not GTiff and other improvements #48 #52
 
 Changed
 *******
 - ``raster.Image()``: update of init signature to be less confusing #41 #50
+- ``raster.Image()``: in-memory dataset now always with "GTiff" driver #53
 
 
 [0.4.0]  (2020-06-05)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Fixed
 
 Changed
 *******
+- ``raster.Image()``: renamed `mask_image()` to `mask()`
 - ``raster.Image()``: update of init signature to be less confusing #41 #50
 - ``raster.Image()``: in-memory dataset now always with "GTiff" driver #53
 

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -40,16 +40,16 @@ class DataTest(unittest.TestCase):
 
     def test_init_with_arry_fail_missing_transform(self):
         with self.assertRaises(TypeError):
-            Image(data=self.img.arr, crs=self.img.crs)
+            Image(data=self.img.arr, crs=self.img.dataset.crs)
 
     def test_init_with_array(self):
-        img = Image(self.img.arr, crs=self.img.crs, transform=self.img.transform)
+        img = Image(self.img.arr, crs=self.img.dataset.crs, transform=self.img.dataset.transform)
         self.assertTrue(np.array_equal(self.img.arr, img.arr))
         img.close()
 
     def test_init_with_arry_fail_missing_crs(self):
         with self.assertRaises(TypeError):
-            Image(data=self.img.arr, crs=self.img.transform)
+            Image(data=self.img.arr, crs=self.img.dataset.transform)
 
     def test_dimorder_error(self):
         with self.assertRaises(TypeError):
@@ -60,7 +60,7 @@ class DataTest(unittest.TestCase):
         img_first.mask_image(box(11.9027457562112939, 51.4664152338322580, 11.9477435281016131, 51.5009522690838750,))
         self.assertEqual(img_first.arr.shape, (1, 385, 502))
         self.assertEqual(
-            str(img_first.transform),
+            str(img_first.dataset.transform),
             str(
                 from_bounds(
                     11.9027457562112939,
@@ -78,7 +78,7 @@ class DataTest(unittest.TestCase):
         img_last.mask_image(box(11.9027457562112939, 51.4664152338322580, 11.9477435281016131, 51.5009522690838750,))
         self.assertEqual(img_last.arr.shape, (385, 502, 1))
         self.assertEqual(
-            str(img_last.transform),
+            str(img_last.dataset.transform),
             str(
                 from_bounds(
                     11.9027457562112939,
@@ -92,11 +92,11 @@ class DataTest(unittest.TestCase):
         )
         img_last.close()
 
-        img_first = Image(np.ones((1, 385, 502)), dimorder="first", crs=self.img.crs, transform=self.img.transform)
+        img_first = Image(np.ones((1, 385, 502)), dimorder="first", crs=self.img.dataset.crs, transform=self.img.dataset.transform)
         self.assertEqual(img_first.arr.shape, (1, 385, 502))
         img_first.close()
 
-        img_last = Image(np.ones((385, 502, 1)), dimorder="last", crs=self.img.crs, transform=self.img.transform)
+        img_last = Image(np.ones((385, 502, 1)), dimorder="last", crs=self.img.dataset.crs, transform=self.img.dataset.transform)
         self.assertEqual(img_last.arr.shape, (385, 502, 1))
         img_last.close()
 
@@ -139,13 +139,14 @@ class DataTest(unittest.TestCase):
         )
 
     def test_warp(self):
-        self.assertEqual(self.img.crs, "EPSG:4326")
+        self.assertEqual(self.img.dataset.crs, "EPSG:4326")
 
         self.img.warp("EPSG:3857")
-        self.assertEqual(self.img.crs, "EPSG:3857")
+        self.assertEqual(self.img.dataset.crs, "EPSG:3857")
+        self.assertEqual(self.img.dataset.meta["crs"], "EPSG:3857")
 
         self.img.warp("EPSG:4326", resolution=1.0)
-        self.assertEqual(1.0, self.img.transform.to_gdal()[1])
+        self.assertEqual(1.0, self.img.dataset.transform.to_gdal()[1])
 
     def test_dn2toa(self):
         target_dir = os.path.join(os.path.dirname(__file__), "testfiles", "satellite_data")
@@ -242,7 +243,7 @@ class DataTest(unittest.TestCase):
         img2.close()
         os.remove(r"result.tif")
 
-        img3 = Image(self.img.arr, crs=self.img.crs, transform=self.img.transform)
+        img3 = Image(self.img.arr, crs=self.img.dataset.crs, transform=self.img.dataset.transform)
         img3.write_to_file(r"result.tif", np.uint16)
         img3.close()
         img4 = Image("result.tif")

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -57,7 +57,7 @@ class DataTest(unittest.TestCase):
 
     def test_arr(self):
         img_first = Image(TEST_FILE, dimorder="first")
-        img_first.mask_image(box(11.9027457562112939, 51.4664152338322580, 11.9477435281016131, 51.5009522690838750,))
+        img_first.mask(box(11.9027457562112939, 51.4664152338322580, 11.9477435281016131, 51.5009522690838750, ))
         self.assertEqual(img_first.arr.shape, (1, 385, 502))
         self.assertEqual(
             str(img_first.dataset.transform),
@@ -75,7 +75,7 @@ class DataTest(unittest.TestCase):
         img_first.close()
 
         img_last = Image(TEST_FILE, dimorder="last")
-        img_last.mask_image(box(11.9027457562112939, 51.4664152338322580, 11.9477435281016131, 51.5009522690838750,))
+        img_last.mask(box(11.9027457562112939, 51.4664152338322580, 11.9477435281016131, 51.5009522690838750, ))
         self.assertEqual(img_last.arr.shape, (385, 502, 1))
         self.assertEqual(
             str(img_last.dataset.transform),
@@ -114,9 +114,9 @@ class DataTest(unittest.TestCase):
 
     def test_mask_image(self):
         with self.assertRaises(TypeError, msg="bbox must be of type tuple or Shapely Polygon"):
-            self.img.mask_image([1, 2, 3])
+            self.img.mask([1, 2, 3])
 
-        self.img.mask_image(box(11.9027457562112939, 51.4664152338322580, 11.9477435281016131, 51.5009522690838750,))
+        self.img.mask(box(11.9027457562112939, 51.4664152338322580, 11.9477435281016131, 51.5009522690838750, ))
         self.assertEqual(
             self.img.dataset.bounds,
             BoundingBox(
@@ -124,7 +124,7 @@ class DataTest(unittest.TestCase):
             ),
         )
 
-        self.img.mask_image((11.9027457562112939, 51.4664152338322580, 11.9477435281016131, 51.5009522690838750,))
+        self.img.mask((11.9027457562112939, 51.4664152338322580, 11.9477435281016131, 51.5009522690838750,))
         self.assertEqual(
             self.img.dataset.bounds,
             BoundingBox(
@@ -132,7 +132,7 @@ class DataTest(unittest.TestCase):
             ),
         )
 
-        self.img.mask_image(
+        self.img.mask(
             box(11.8919236802142620, 51.4664152338322580, 11.9477435281016131, 51.5009522690838750,), pad=True,
         )
         self.assertEqual(

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -92,11 +92,15 @@ class DataTest(unittest.TestCase):
         )
         img_last.close()
 
-        img_first = Image(np.ones((1, 385, 502)), dimorder="first", crs=self.img.dataset.crs, transform=self.img.dataset.transform)
+        img_first = Image(
+            np.ones((1, 385, 502)), dimorder="first", crs=self.img.dataset.crs, transform=self.img.dataset.transform
+        )
         self.assertEqual(img_first.arr.shape, (1, 385, 502))
         img_first.close()
 
-        img_last = Image(np.ones((385, 502, 1)), dimorder="last", crs=self.img.dataset.crs, transform=self.img.dataset.transform)
+        img_last = Image(
+            np.ones((385, 502, 1)), dimorder="last", crs=self.img.dataset.crs, transform=self.img.dataset.transform
+        )
         self.assertEqual(img_last.arr.shape, (385, 502, 1))
         img_last.close()
 

--- a/ukis_pysat/raster.py
+++ b/ukis_pysat/raster.py
@@ -105,7 +105,7 @@ class Image:
         # update for further processing
         self.dataset.close()  # meta still available when DataSetReader is closed
         # passing meta to open, because driver gets lost if it's not GTiff
-        self.dataset = self.__update_dataset(self.dataset.meta, self.dataset.crs, transform).open(**self.dataset.meta)
+        self.dataset = self.__update_dataset(self.dataset.meta, self.dataset.crs, transform).open()
 
     def _pad_to_bbox(self, bbox, mode="constant", constant_values=0):
         """Buffers array with biggest difference to bbox and adjusts affine transform matrix. Can be used to fill
@@ -210,8 +210,7 @@ class Image:
         self.__arr = destination
 
         self.dataset.close()
-        # passing meta to open, because driver gets lost if it's not GTiff
-        self.dataset = self.__update_dataset(self.dataset.meta, dst_crs, transform).open(**self.dataset.meta)
+        self.dataset = self.__update_dataset(self.dataset.meta, dst_crs, transform).open()
 
     def dn2toa(self, platform, mtl_file=None, wavelengths=None):
         """This method converts digital numbers to top of atmosphere reflectance, like described here:
@@ -281,6 +280,8 @@ class Image:
                 f"Cannot convert dn2toa. Platform {platform} not supported [Landsat-5, Landsat-7, Landsat-8, "
                 f"Sentinel-2]. "
             )
+
+        self.dataset = self.__update_dataset(self.dataset.meta, self.dataset.crs, self.dataset.transform).open()
 
     @staticmethod
     def _lookup_bands(platform, wavelengths):

--- a/ukis_pysat/raster.py
+++ b/ukis_pysat/raster.py
@@ -80,6 +80,12 @@ class Image:
         return windows.bounds(valid_data_window, windows.transform(valid_data_window, self.dataset.transform))
 
     def mask_image(self, bbox, crop=True, pad=False, mode="constant", constant_values=0):
+        from warnings import warn
+
+        warn("`mask_image()` was renamed to `mask()` and will be removed with version 0.6.0", DeprecationWarning)
+        return self.mask(bbox, crop=crop, pad=pad, mode=mode, constant_values=constant_values)
+
+    def mask(self, bbox, crop=True, pad=False, mode="constant", constant_values=0):
         """Mask the area outside of the input shapes with no data.
 
         :param bbox: bounding box of type tuple or Shapely Polygon
@@ -140,6 +146,7 @@ class Image:
 
         self.__arr = destination
 
+        self.dataset.close()
         return self.__update_dataset(self.dataset.crs, transform, nodata=self.dataset.nodata)
 
     def __update_dataset(self, crs, transform, nodata=None):
@@ -281,6 +288,7 @@ class Image:
                 f"Sentinel-2]. "
             )
 
+        self.dataset.close()
         self.dataset = self.__update_dataset(self.dataset.crs, self.dataset.transform, nodata=self.dataset.nodata)
 
     @staticmethod


### PR DESCRIPTION
closes #52 

also simplifies crs & transform, but removes direct access. Now via `dataset`. Bugfix with `dataset.crs` not being updated in memory.