### PR TITLE
45 context manager for raster

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@ something was changed
 
 [master]  (2020-**-**)
 ----------------------
+Added
+*****
+- `raster.Image()``: With Statement Context Manager for Image #45
 
 [0.5.0]  (2020-07-03)
 ----------------------

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -26,6 +26,10 @@ class DataTest(unittest.TestCase):
         self.assertTrue(np.array_equal(self.img.arr, img.arr))
         img.close()
 
+    def test_context(self):
+        with Image(TEST_FILE) as raster_file:
+            self.assertTrue(np.array_equal(self.img.arr, raster_file.arr))
+
     def test_init_fail_invalid_path(self):
         with self.assertRaises(TypeError):
             Image(1)

--- a/ukis_pysat/data.py
+++ b/ukis_pysat/data.py
@@ -127,11 +127,9 @@ class Source:
                         m_cloud_cover = 0
                     if (
                         m_platform == platform.value
-                        and m_date >= start_date
-                        and m_date < end_date
+                        and start_date <= m_date < end_date
                         and m_geom.intersects(geom)
-                        and m_cloud_cover >= min_cloud_cover
-                        and m_cloud_cover < max_cloud_cover
+                        and min_cloud_cover <= m_cloud_cover < max_cloud_cover
                     ):
                         meta_src.append(m)
 
@@ -515,7 +513,3 @@ class MetadataCollection:
 class _GeoInterface(object):
     def __init__(self, d):
         self.__geo_interface__ = d
-
-
-if __name__ == "__main__":
-    pass

--- a/ukis_pysat/data.py
+++ b/ukis_pysat/data.py
@@ -356,7 +356,7 @@ class Source:
         else:
             pass
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, exc_value, traceback):
         self.close()
 
 

--- a/ukis_pysat/raster.py
+++ b/ukis_pysat/raster.py
@@ -62,6 +62,9 @@ class Image:
         else:
             raise TypeError("dataset must be of type rasterio.io.DatasetReader, str or np.ndarray")
 
+    def __enter__(self):
+        return self
+
     @property
     def arr(self):
         """array property"""
@@ -414,3 +417,6 @@ class Image:
     def close(self):
         """closes Image"""
         self.dataset.close()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()


### PR DESCRIPTION
Like discussed, this should do it quite simply. We could rewrite all the tests using this or leave it like it is. Usage:
```python
with Image(data) as img:
    print(img.arr)
```

We could consider writing a more extensive documentation and add it there (besides the auto-generated Python API) if users have questions.

Closes #45 . Squash the commits.
