### PR TITLE
Refactor get_polarization_from_s1_filename

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,8 @@ something was changed
 
 Changed
 *****
-- ``get_polarization_from_s1_filename()``: return type is now only ``str`` instead of ``Union[str, List[str]]``
+- ``get_polarization_from_s1_filename()``: return type is now only ``str`` instead of ``Union[str, List[str]] #92``
+
 Added
 *****
 - ``file``: read and return booleans from env #90

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ something was changed
 [master]  (2020-**-**)
 ----------------------
 
+Changed
+*****
+- ``get_polarization_from_s1_filename()``: return type is now only ``str`` instead of ``Union[str, List[str]]``
 Added
 *****
 - ``file``: read and return booleans from env #90

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -52,7 +52,7 @@ class FileTest(unittest.TestCase):
             psf.get_polarization_from_s1_filename(
                 "MMM_BB_TTTR_1SDV_YYYYMMDDTHHMMSS_YYYYMMDDTHHMMSS_OOOOOO_DDDDDD_CCCC.SAFE.zip", True,
             ),
-            ["VV", "VH"],
+            "VV,VH",
         )
 
     def test_get_ts_from_sentinel_filename(self):

--- a/ukis_pysat/file.py
+++ b/ukis_pysat/file.py
@@ -62,13 +62,13 @@ def get_sentinel_scene_from_dir(indir: Union[str, Path]) -> Iterator[Tuple[Path,
             yield full_path, ident
 
 
-def get_polarization_from_s1_filename(filename: str, dual: bool = False) -> Union[str, List[str]]:
+def get_polarization_from_s1_filename(filename: str, dual: bool = False) -> str:
     """Get polarization from the filename of a Sentinel-1 scene.
     https://sentinel.esa.int/web/sentinel/user-guides/sentinel-1-sar/naming-conventions.
 
     :param filename: top-level SENTINEL-1 product folder name
     :param dual: boolean (default: True), optional
-    :return: str or list
+    :return: str
 
     >>> get_polarization_from_s1_filename("MMM_BB_TTTR_1SDH_YYYYMMDDTHHMMSS_YYYYMMDDTHHMMSS_OOOOOO_DDDDDD_CCCC.SAFE.zip")
     'HH'
@@ -77,18 +77,18 @@ def get_polarization_from_s1_filename(filename: str, dual: bool = False) -> Unio
     >>> get_polarization_from_s1_filename("MMM_BB_TTTR_2SSV_YYYYMMDDTHHMMSS_YYYYMMDDTHHMMSS_OOOOOO_DDDDDD_CCCC.SAFE.zip")
     'VV'
     >>> get_polarization_from_s1_filename("MMM_BB_TTTR_1SDV_YYYYMMDDTHHMMSS_YYYYMMDDTHHMMSS_OOOOOO_DDDDDD_CCCC.SAFE.zip", True)
-    ['VV', 'VH']
+    'VV,VH'
     """
-    polarization_dict: Dict[str, Union[str, List[str]]] = {
+    polarization_dict: Dict[str, str] = {
         "SSV": "VV",
         "SSH": "HH",
-        "SDV": ["VV", "VH"],
-        "SDH": ["HH", "HV"],
+        "SDV": "VV,VH",
+        "SDH": "HH,HV",
     }
 
-    polarization: Union[str, List[str]] = polarization_dict[filename[13:16]]
-    if not dual and isinstance(polarization, list):
-        return polarization[0]
+    polarization: str = polarization_dict[filename[13:16]]
+    if not dual and ',' in polarization:
+        return polarization.split(',')[0]
     else:
         return polarization
 


### PR DESCRIPTION
This commit refactors the ukis-pysat/file.py method ```get_polarization_from_s1_filename``` according to the new requirements specified at issue #92. 

Now the method returns polarization values only as ```str``` instead of previous polarization values that could be  ```Union[str, List[str]]```. Changes in the method includes also the docstring and variable typing.

After the updates, all tests passed.

If it is your will, could you label this PR as ```hacktoberfest-accepted```? So then I can get this as a valid contribution to the festival.