### PR TITLE
make dependencies optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Changed
 - ``data``: mocked all interaction with Hubs for unit testing #116
 - ``data``: EarthExplorer changed to new M2M API due to dependency update #120
 - split unit tests #110
+- removed hard dependency for landsatxplore & pylandsat #104
 
 Added
 ^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,8 @@ Changed
 - ``data``: mocked all interaction with Hubs for unit testing #116
 - ``data``: EarthExplorer changed to new M2M API due to dependency update #120
 - split unit tests #110
-- removed hard dependency for landsatxplore & pylandsat #104
+- ``data``: removed hard dependency for landsatxplore & pylandsat #104
+
 
 Added
 ^^^^^

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,8 @@ def get_version(rel_path):
 # please also update requirements.txt for testing. Make sure package versions are the same in each subset.
 extras_require = {
     "data": [
-        "landsatxplore>=0.13.0",
         "numpy",
         "pillow",
-        "pylandsat>=0.6.0",
         "pystac>=0.5.5",
         "python-dateutil",
         "requests",
@@ -51,7 +49,9 @@ extras_require["dev"] = sorted(
     + [
         "dask[array]",
         "fiona",
+        "landsatxplore>=0.13.0",
         "pandas",
+        "pylandsat>=0.6.0",
         "pyproj>=3.0.0",
         "requests_mock",
         "utm>=0.7.0",

--- a/ukis_pysat/data.py
+++ b/ukis_pysat/data.py
@@ -11,14 +11,11 @@ from dateutil.parser import parse
 from ukis_pysat.stacapi import StacApi
 
 try:
-    import landsatxplore.api
     import numpy as np
     import pystac
     import requests
     import sentinelsat
-    from landsatxplore.util import guess_dataset
     from PIL import Image
-    from pylandsat import Product
     from pystac.extensions import sat
     from shapely import geometry, wkt, ops
 except ImportError as e:
@@ -75,6 +72,8 @@ class Source:
                 self.api = StacApi()
 
         elif self.src == Datahub.EarthExplorer:
+            import landsatxplore.api
+
             # connect to Earthexplorer
             self.user = env_get("EARTHEXPLORER_USER")
             self.pw = env_get("EARTHEXPLORER_PW")
@@ -214,6 +213,8 @@ class Source:
             )
 
         elif self.src == Datahub.EarthExplorer:
+            from landsatxplore.util import guess_dataset
+
             dataset = guess_dataset(srcid)
             metadata = self.api.metadata(self.api.get_entity_id(srcid, dataset), dataset)
 
@@ -322,6 +323,8 @@ class Source:
             product_srcid = meta_src[0]["displayId"]
 
             if not Path(target_dir.joinpath(product_srcid + ".zip")).is_file():
+                from pylandsat import Product
+
                 # download data from AWS if file does not already exist
                 product = Product(product_srcid)
                 product.download(out_dir=target_dir, progressbar=False)


### PR DESCRIPTION
Closes #104.

The normal error raised should be self-explanatory. This makes `ukis-pysat[data]` much more lightweight to install and we do not require GDAL, etc. anymore. EarthExplorer (or USGS M2M) can still be used, but the necessary dependencies are not installed by default, more details here: https://github.com/dlr-eoc/ukis-pysat/issues/104#issuecomment-802913849

In the future we might think about making `ukis-pysat[raster]` it's own library.