### PR TITLE
Expose fileobj to stream scenes

### DIFF
--- a/ukis_pysat/data.py
+++ b/ukis_pysat/data.py
@@ -341,6 +341,26 @@ class Source:
         else:
             self.api.download(product_uuid, target_dir, checksum=True)
 
+    def get_download_bytes(self, product_uuid):
+        """
+        Get download bytes for streaming them directly to e.g. S3.
+
+        :param product_uuid: UUID of the satellite image product (String).
+        :returns: raw socket response from the server
+        """
+        if self.src == Datahub.Scihub:
+            product_info = self.api.get_product_odata(product_uuid)
+            if not product_info["Online"]:
+                raise NotImplementedError("Product is offline, no retrieval implemented.")
+            r = requests.get(
+                product_info["url"],
+                stream=True,
+                auth=self.api.session.auth,
+            )
+            return r.raw
+        else:
+            raise NotImplementedError(f"Only implemented for {Datahub.Scihub.value}.")
+
     def download_quicklook(self, platform, product_uuid, target_dir):
         """Downloads a quicklook of the satellite image to a target directory for a specific product_id.
         It performs a very rough geocoding of the quicklooks by shifting the image to the location of the footprint.

--- a/ukis_pysat/data.py
+++ b/ukis_pysat/data.py
@@ -346,7 +346,7 @@ class Source:
         Get download bytes for streaming them directly to e.g. S3.
 
         :param product_uuid: UUID of the satellite image product (String).
-        :returns: raw socket response from the server
+        :returns: raw socket response from the server (Bytes), md5sum (String)
         """
         if self.src == Datahub.Scihub:
             product_info = self.api.get_product_odata(product_uuid)
@@ -357,7 +357,7 @@ class Source:
                 stream=True,
                 auth=self.api.session.auth,
             )
-            return r.raw
+            return r.raw, product_info["md5"]
         else:
             raise NotImplementedError(f"Only implemented for {Datahub.Scihub.value}.")
 


### PR DESCRIPTION
It would be quite handy to not having to write to disk when we want to download files to S3. With the current solution we could for example do something like that using `minio-py`
```python
s3client.put_object(bucket_name, object_name, response[0], length=-1, part_size=10 * 1024 * 1024, )
```
and then verify the checksum. `response` would be what's returned from `self.get_download_bytes()`. I guess we leave handling of the response out of this library because who knows what else you would want to do with this.

Let's start with Scihub and handlet the others later, once we are certain how to continue with them.

@j08lue you discussed something like this in https://github.com/sentinelsat/sentinelsat/issues/396, would you want a PR in `sentinelsat`? In that case we would not merge here.