### PR TITLE
allow `get` for item-search if `post` is not allowed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+[Unreleased] (**-*-*)
+---------------------
+Added
+^^^^^
+- ``data``: allow `get` on item-search with geometry if `post` is not allowed
+
 [1.3.1] (2021-08-02)
 ---------------------
 Fixed

--- a/tests/test_stacapi.py
+++ b/tests/test_stacapi.py
@@ -60,8 +60,9 @@ class StacApiTest(unittest.TestCase):
 
     def test_get_items_aoi_GET(self):
         new_api = StacApi("https://tamn.snapplanet.io/")  # based on resto, no post enabled for "intersects"
-        items = new_api.get_items(collection="L8", intersects=self.aoi)
+        items = new_api.get_items(collection="L8", intersects=self.aoi, limit=1)
         self.assertEqual(items[0].id, "99b32d9d-0ded-5f57-9698-357bc89c6097")
+        self.assertEqual(1, len(items))
 
 
 if __name__ == "__main__":

--- a/tests/test_stacapi.py
+++ b/tests/test_stacapi.py
@@ -58,6 +58,11 @@ class StacApiTest(unittest.TestCase):
         items = self.api.get_items(collection="sentinel-s2-l2a", intersects=self.aoi, limit=limit)
         self.assertEqual(limit, len(items))
 
+    def test_get_items_aoi_GET(self):
+        new_api = StacApi("https://tamn.snapplanet.io/")  # based on resto, no post enabled for "intersects"
+        items = new_api.get_items(collection="L8", intersects=self.aoi)
+        self.assertEqual(items[0].id, "99b32d9d-0ded-5f57-9698-357bc89c6097")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/ukis_pysat/stacapi.py
+++ b/ukis_pysat/stacapi.py
@@ -60,14 +60,13 @@ class StacApi:
         res = self._handle_query(headers=headers, **kwargs)
         return res["context"]["matched"]
 
-    def get_items(self, limit=100, headers=None, **kwargs):
+    def get_items(self, headers=None, **kwargs):
         """get items or single item
-        :param limit: max number of items returned (default 100)
         :param headers: headers (optional)
         :param kwargs: search parameters (optional) See: https://github.com/radiantearth/stac-api-spec/tree/master/item-search#query-parameter-table
-        :returns list with pystac.items"""
+        :returns list with pystac.Items"""
         next_page = urljoin(self.url, "search")
-        limit = kwargs.get("limit", limit)
+        limit = kwargs.get("limit", 100)
         items = []
 
         while next_page:

--- a/ukis_pysat/stacapi.py
+++ b/ukis_pysat/stacapi.py
@@ -40,7 +40,7 @@ class StacApi:
     def _query(url, kwargs, headers):
         if {"intersects", "bbox"}.intersection(kwargs):
             r = requests.post(url, json=kwargs, headers=headers)
-            if r.status_code == 405:
+            if r.status_code == 405:  # Method Not Allowed, fallback to GET
                 if "intersects" in kwargs:
                     kwargs["intersects"] = str(kwargs["intersects"])
                 if "bbox" in kwargs:


### PR DESCRIPTION
`post` is [recommended](https://github.com/radiantearth/stac-api-spec/tree/master/item-search#post), but not all endpoints allow it.

That's the case for e.g. [resto](https://github.com/jjrom/resto).